### PR TITLE
chore: build for `musl` based systems

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ ci = "github"
 # The installers to generate for each app
 installers = ["shell", "powershell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # Publish jobs to run in CI
 pr-run-mode = "plan"
 # Whether to install an updater program


### PR DESCRIPTION
As noted in #31, we currently can only deploy this to Linux
distributions that use `glibc`, which means some more lightweight
distributions like Alpine Linux aren't usable.

We should be able to solve this by adding a target to `-musl`.

Closes #31.
